### PR TITLE
feat: resolve typescript issues with testing suite

### DIFF
--- a/test/App.test.tsx
+++ b/test/App.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import App from '../src/App';
 import { describe, it, expect, beforeEach } from 'vitest';

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -5,7 +5,7 @@
     "useDefineForClassFields": true,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
-    "types": ["vite/client"],
+    "types": ["vite/client", "vitest/globals", "@testing-library/jest-dom"],
     "skipLibCheck": true,
 
     /* Bundler mode */
@@ -24,5 +24,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src", "test"]
 }


### PR DESCRIPTION
- Update tsconfig.app.json to include the "test" directory
- Add "vitest/globals" and "@testing-library/jest-dom" to the compiler types to resolve toBeInTheDocument typescript errors
- Remove unused 'waitFor' import from App.test.tsx