### PR TITLE
feat: add info tooltips for Width, Type, and Action labels

### DIFF
--- a/src/ConvertModeButton.tsx
+++ b/src/ConvertModeButton.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import InfoTooltip from "./InfoTooltip";
 
 interface ConvertModeButtonProps {
     currentMode: number;
@@ -21,7 +22,10 @@ const ConvertModeButton: React.FC<ConvertModeButtonProps> = ({
         <div className="flex flex-col gap-3 mx-2 p-2 bg-slate-50 dark:bg-slate-800/50 rounded-xl transition-colors">
             {/* Row 1: Width Selection */}
             <div className="flex items-center gap-4">
-                <span className="text-[10px] font-black text-slate-400 dark:text-slate-500 uppercase w-10">Width</span>
+                <span className="flex items-center gap-1.5 text-[12px] font-black text-slate-400 dark:text-slate-500 uppercase w-16">
+                    Width
+                    <InfoTooltip text="Choose how many bits to display (8, 16, or 32)." />
+                </span>
                 <div className="flex gap-2">
                     {[8, 16, 32].map(mode => (
                         <button
@@ -41,7 +45,10 @@ const ConvertModeButton: React.FC<ConvertModeButtonProps> = ({
 
             {/* Row 2: Signed Mode Selection */}
             <div className="flex items-center gap-4">
-                <span className="text-[10px] font-black text-slate-400 dark:text-slate-500 uppercase w-10">Type</span>
+                <span className="flex items-center gap-1 text-[12px] font-black text-slate-400 dark:text-slate-500 uppercase w-16">
+                    Type
+                    <InfoTooltip text="Unsigned treats all bits as positive value; Signed uses two's complement." />
+                </span>
                 <div className="flex gap-2">
                     {["unsigned", "signed"].map(mode => (
                         <button
@@ -61,7 +68,10 @@ const ConvertModeButton: React.FC<ConvertModeButtonProps> = ({
 
             {/* Row 3: Click Action Selection */}
             <div className="flex items-center gap-4">
-                <span className="text-[10px] font-black text-slate-400 dark:text-slate-500 uppercase w-10">Action</span>
+                <span className="flex items-center gap-1.5 text-[12px] font-black text-slate-400 dark:text-slate-500 uppercase w-16">
+                    Action
+                    <InfoTooltip text="Flip toggles a single bit; Add increments the value by that bit's weight." />
+                </span>
                 <div className="flex gap-2">
                     {["flip", "add"].map(mode => (
                         <button

--- a/src/InfoTooltip.tsx
+++ b/src/InfoTooltip.tsx
@@ -1,0 +1,77 @@
+import React, { useState, useRef, useEffect } from "react";
+import { createPortal } from "react-dom";
+
+interface InfoTooltipProps {
+  text: string;
+}
+
+const InfoTooltip: React.FC<InfoTooltipProps> = ({ text }) => {
+  const [isVisible, setIsVisible] = useState(false);
+  const [coords, setCoords] = useState({ top: 0, left: 0 });
+  const triggerRef = useRef<HTMLDivElement>(null);
+
+  const updatePosition = () => {
+    if (triggerRef.current) {
+      const rect = triggerRef.current.getBoundingClientRect();
+      setCoords({
+        top: rect.top - 10, // Margin from the icon
+        left: rect.left + rect.width / 2,
+      });
+    }
+  };
+
+  useEffect(() => {
+    if (isVisible) {
+      updatePosition();
+      window.addEventListener("scroll", updatePosition);
+      window.addEventListener("resize", updatePosition);
+    }
+    return () => {
+      window.removeEventListener("scroll", updatePosition);
+      window.removeEventListener("resize", updatePosition);
+    };
+  }, [isVisible]);
+
+  return (
+    <div
+      ref={triggerRef}
+      className="inline-flex items-center justify-center ml-0.5"
+      onMouseEnter={() => setIsVisible(true)}
+      onMouseLeave={() => setIsVisible(false)}
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="11"
+        height="11"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className="text-slate-300 hover:text-slate-500 dark:text-slate-600 dark:hover:text-slate-400 transition-colors cursor-help"
+      >
+        <circle cx="12" cy="12" r="10" />
+        <path d="M12 16v-4" />
+        <path d="M12 8h.01" />
+      </svg>
+
+      {isVisible &&
+        createPortal(
+          <div
+            className="fixed w-56 p-2.5 bg-slate-800 dark:bg-slate-700 text-white text-[10px] font-medium leading-relaxed rounded-xl shadow-2xl z-[999] text-center border border-white/10 pointer-events-none -translate-x-1/2 -translate-y-full"
+            style={{
+              top: `${coords.top}px`,
+              left: `${coords.left}px`,
+            }}
+          >
+            {text}
+            <div className="absolute top-full left-1/2 -translate-x-1/2 -mt-1 border-[5px] border-transparent border-t-slate-800 dark:border-t-slate-700"></div>
+          </div>,
+          document.body
+        )}
+    </div>
+  );
+};
+
+export default InfoTooltip;


### PR DESCRIPTION
This PR adds i-icon tooltips with explanations for the key feature labels. It uses React Portals to ensure the tooltips are visible even when parents have overflow-hidden.