### PR TITLE
feat: add GitHub Packages workflow for Docker container image

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,49 @@
+name: Package
+
+on:
+  push:
+    branches: ["main"]
+    tags: ["v*"]
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ id.meta.outputs.tags }}
+          labels: ${{ id.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ The name **Flibit** comes from the term "bit flip" (a hardware phenomenon where 
 1. Clone the repository: `git clone https://github.com/jisteven-epfl/flibit-converter.git`
 2. Install dependencies: `npm install`
 3. Run the development server: `npm run dev`
+4. **Run with Docker**:
+   ```bash
+   docker pull ghcr.io/jisteven-epfl/flibit-converter:latest
+   docker run -p 8080:80 ghcr.io/jisteven-epfl/flibit-converter:latest
+   ```
+   Then visit `http://localhost:8080`.
 
 ### 🧰 Tech Stack
 
@@ -88,6 +94,12 @@ Furthermore, this project serves as an exploration into **AI-native workflows**.
 1. 克隆仓库: `git clone https://github.com/jisteven-epfl/flibit-converter.git`
 2. 安装依赖: `npm install`
 3. 运行开发服务器: `npm run dev`
+4. **通过 Docker 运行**:
+   ```bash
+   docker pull ghcr.io/jisteven-epfl/flibit-converter:latest
+   docker run -p 8080:80 ghcr.io/jisteven-epfl/flibit-converter:latest
+   ```
+   然后访问 `http://localhost:8080`。
 
 ### 🧰 技术栈
 


### PR DESCRIPTION
## Summary
This PR introduces automated container packaging for the flibit-converter application using GitHub Container Registry (GHCR). It also adds clear documentation on how to pull and run the application using Docker.

## Changes
- New Workflow: Added `.github/workflows/package.yml` to automate the build-and-push process.
  - Triggers: On every push to main and on any tags matching v* (e.g., v1.0.0).
  - Tagging Strategy: Automatically tags images with latest, the semantic version, and the commit SHA.
  - Security: Uses the built-in GITHUB_TOKEN for secure login to GHCR.
- Documentation: Updated `README.md` with a new Docker (GitHub Packages) section in both English and Chinese translations.